### PR TITLE
Fixes coding style by re-ordering functions

### DIFF
--- a/src/knot_cloud.h
+++ b/src/knot_cloud.h
@@ -52,6 +52,14 @@ typedef bool (*knot_cloud_cb_t) (const struct knot_cloud_msg *msg,
 typedef void (*knot_cloud_connected_cb_t) (void *user_data);
 typedef void (*knot_cloud_disconnected_cb_t) (void *user_data);
 
+int knot_cloud_register_device(const char *id, const char *name);
+int knot_cloud_unregister_device(const char *id);
+int knot_cloud_auth_device(const char *id, const char *token);
+int knot_cloud_update_schema(const char *id, struct l_queue *schema_list);
+int knot_cloud_list_devices(void);
+int knot_cloud_publish_data(const char *id, uint8_t sensor_id,
+			    uint8_t value_type, const knot_value_type *value,
+			    uint8_t kval_len);
 int knot_cloud_read_start(const char *id, knot_cloud_cb_t read_handler_cb,
 			  void *user_data);
 int knot_cloud_start(char *url, char *user_token,
@@ -59,11 +67,4 @@ int knot_cloud_start(char *url, char *user_token,
 		     knot_cloud_disconnected_cb_t disconnected_cb,
 		     void *user_data);
 void knot_cloud_stop(void);
-int knot_cloud_list_devices(void);
-int knot_cloud_publish_data(const char *id, uint8_t sensor_id,
-			    uint8_t value_type, const knot_value_type *value,
-			    uint8_t kval_len);
-int knot_cloud_register_device(const char *id, const char *name);
-int knot_cloud_unregister_device(const char *id);
-int knot_cloud_auth_device(const char *id, const char *token);
-int knot_cloud_update_schema(const char *id, struct l_queue *schema_list);
+

--- a/src/mq.h
+++ b/src/mq.h
@@ -42,11 +42,10 @@ int8_t mq_publish_fanout_message(const char *exchange,
 				 size_t num_headers,
 				 uint64_t expiration_ms,
 				 const char *body);
-
-amqp_bytes_t mq_declare_new_queue(const char *name);
-int mq_delete_queue(amqp_bytes_t queue);
 int mq_prepare_direct_queue(amqp_bytes_t queue, const char *exchange,
 			    const char *routing_key);
+amqp_bytes_t mq_declare_new_queue(const char *name);
+int mq_delete_queue(amqp_bytes_t queue);
 int mq_consumer_queue(amqp_bytes_t queue);
 
 int mq_set_read_cb(mq_read_cb_t read_cb, void *user_data);

--- a/src/parser.h
+++ b/src/parser.h
@@ -16,24 +16,22 @@
 
 typedef void *(*parser_json_array_item_cb) (json_object *array_item);
 
-struct l_queue *parser_schema_to_list(const char *json_str);
-struct l_queue *parser_queue_from_json_array(json_object *jobj,
-				parser_json_array_item_cb foreach_cb);
-
-struct l_queue *parser_request_to_list(json_object *jso);
-json_object *parser_sensorid_to_json(const char *key, struct l_queue *list);
+json_object *parser_schema_create_object(const char *device_id,
+					 struct l_queue *schema_list);
 struct l_queue *parser_update_to_list(json_object *jso);
-
 json_object *parser_data_create_object(const char *device_id, uint8_t sensor_id,
 				uint8_t value_type,
 				const knot_value_type *value,
 				uint8_t kval_len);
+struct l_queue *parser_schema_to_list(const char *json_str);
+struct l_queue *parser_queue_from_json_array(json_object *jobj,
+				parser_json_array_item_cb foreach_cb);
+struct l_queue *parser_request_to_list(json_object *jso);
+json_object *parser_sensorid_to_json(const char *key, struct l_queue *list);
 json_object *parser_device_json_create(const char *device_id,
 				       const char *device_name);
 json_object *parser_auth_json_create(const char *device_id,
 				     const char *device_token);
 json_object *parser_unregister_json_create(const char *device_id);
-json_object *parser_schema_create_object(const char *device_id,
-					 struct l_queue *schema_list);
 const char *parser_get_key_str_from_json_obj(json_object *jso, const char *key);
 bool parser_is_key_str_or_null(const json_object *jso, const char *key);


### PR DESCRIPTION
- Re-order local methods in header files in order to be in accordance with .c implementation files,
- Re-order static methods in .c implementation files to be in accordance with the local methods calls,
  (The static methods were ordered descending - bottom (first to be called) to top (last to be called)).
- The files which were changed are listed as follow:
  src/knot_cloud.c (implemetation file)
  src/knot_cloud.h (header file)
  src/mq.c
  src/mq.h
  src/parser.c
  src/parser.h