### PR TITLE
Create log configuration functions

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -1,5 +1,5 @@
 lib_headers = knot_cloud.h
-lib_sources = knot_cloud.c parser.c parser.h mq.c mq.h
+lib_sources = knot_cloud.c parser.c parser.h mq.c mq.h log.c log.h
 
 modules_libadd = @ELL_LIBS@ @JSON_LIBS@ @RABBITMQ_LIBS@ @KNOTPROTO_LIBS@
 modules_cflags = @ELL_CFLAGS@ @JSON_CFLAGS@ @RABBITMQ_CFLAGS@ @KNOTPROTO_CFLAGS@

--- a/src/knot_cloud.c
+++ b/src/knot_cloud.c
@@ -38,6 +38,7 @@
 
 #include "mq.h"
 #include "parser.h"
+#include "log.h"
 #include "knot_cloud.h"
 
 #define MQ_QUEUE_FOG_OUT "thingd-fogOut"
@@ -713,6 +714,7 @@ int knot_cloud_start(char *url, char *user_token,
 		     knot_cloud_disconnected_cb_t disconnected_cb,
 		     void *user_data)
 {
+	log_ell_enable();
 	user_auth_token = l_strdup(user_token);
 	headers[0].key = amqp_cstring_bytes(MQ_AUTHORIZATION_HEADER);
 	headers[0].value.kind = AMQP_FIELD_KIND_UTF8;

--- a/src/knot_cloud.c
+++ b/src/knot_cloud.c
@@ -387,6 +387,26 @@ static void destroy_cloud_queue(void)
 }
 
 /**
+ * knot_cloud_set_log_priority:
+ * @priority: Log Priority
+ *
+ * Changes the knot cloud SDK log priority.
+ *
+ * Returns: void.
+ */
+void knot_cloud_set_log_priority(char *priority)
+{
+	if (!strcmp(priority,"error"))
+		log_set_priority(L_LOG_ERR);
+	else if (!strcmp(priority,"warn"))
+		log_set_priority(L_LOG_WARNING);
+	else if (!strcmp(priority,"info"))
+		log_set_priority(L_LOG_INFO);
+	else if (!strcmp(priority,"debug"))
+		log_set_priority(L_LOG_DEBUG);
+}
+
+/**
  * knot_cloud_register_device:
  * @id: device id
  * @name: device name

--- a/src/knot_cloud.h
+++ b/src/knot_cloud.h
@@ -52,6 +52,7 @@ typedef bool (*knot_cloud_cb_t) (const struct knot_cloud_msg *msg,
 typedef void (*knot_cloud_connected_cb_t) (void *user_data);
 typedef void (*knot_cloud_disconnected_cb_t) (void *user_data);
 
+void knot_cloud_set_log_priority(char *priority);
 int knot_cloud_register_device(const char *id, const char *name);
 int knot_cloud_unregister_device(const char *id);
 int knot_cloud_auth_device(const char *id, const char *token);

--- a/src/log.c
+++ b/src/log.c
@@ -59,6 +59,13 @@ static void log_stderr_handler(int priority, const char *file, const char *line,
 	vfprintf(stderr, format, ap);
 }
 
+void log_set_priority(int priority)
+{
+	log_priority = priority;
+	if (log_priority == L_LOG_DEBUG)
+		l_debug_enable("*");
+}
+
 void log_ell_enable(void)
 {
 	l_log_set_handler(log_stderr_handler);

--- a/src/log.c
+++ b/src/log.c
@@ -1,0 +1,65 @@
+/*
+ * This file is part of the KNOT Project
+ *
+ * Copyright (c) 2020, CESAR. All rights reserved.
+ *
+ *  This library is free software; you can redistribute it and/or
+ *  modify it under the terms of the GNU Lesser General Public
+ *  License as published by the Free Software Foundation; either
+ *  version 2.1 of the License, or (at your option) any later version.
+ *
+ *  This library is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ *  Lesser General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Lesser General Public
+ *  License along with this library; if not, write to the Free Software
+ *  Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ */
+
+/**
+ * Log source file
+ */
+
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <ell/ell.h>
+#include <errno.h>
+
+#include "log.h"
+
+static int log_priority = L_LOG_ERR;
+
+static void log_stderr_handler(int priority, const char *file, const char *line,
+			       const char *func, const char *format, va_list ap)
+{
+	if (priority > log_priority)
+		return;
+
+	switch (priority) {
+	case L_LOG_ERR:
+		fprintf(stderr, "ERR: %s() ", func);
+		break;
+	case L_LOG_WARNING:
+		fprintf(stderr, "WARN: ");
+		break;
+	case L_LOG_INFO:
+		fprintf(stderr, "INFO: ");
+		break;
+	case L_LOG_DEBUG:
+		fprintf(stderr, "DEBUG: ");
+		break;
+	default:
+		return;
+	}
+
+	vfprintf(stderr, format, ap);
+}
+
+void log_ell_enable(void)
+{
+	l_log_set_handler(log_stderr_handler);
+}

--- a/src/log.h
+++ b/src/log.h
@@ -23,4 +23,5 @@
  * Log header file
  */
 
+void log_set_priority(int priority);
 void log_ell_enable(void);

--- a/src/log.h
+++ b/src/log.h
@@ -1,0 +1,26 @@
+/*
+ * This file is part of the KNOT Project
+ *
+ * Copyright (c) 2020, CESAR. All rights reserved.
+ *
+ *  This library is free software; you can redistribute it and/or
+ *  modify it under the terms of the GNU Lesser General Public
+ *  License as published by the Free Software Foundation; either
+ *  version 2.1 of the License, or (at your option) any later version.
+ *
+ *  This library is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ *  Lesser General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Lesser General Public
+ *  License along with this library; if not, write to the Free Software
+ *  Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ */
+
+/**
+ * Log header file
+ */
+
+void log_ell_enable(void);


### PR DESCRIPTION
Changes:

- Create src/log.c and src/log.h and Add them to src/Makefile.am;
- Create ell lib configuration functions;
- Include log.h in knot_cloud.c;
- Setup log configurations inside knot_cloud_start function;
- Create knot_cloud_set_log_priority, this function lets the user
choose the SDK log priority level;
- Add function to knot_cloud.h
