### PR TITLE
Remove knot-protocol from knot-cloud-sdk header

### DIFF
--- a/src/knot_cloud.c
+++ b/src/knot_cloud.c
@@ -607,16 +607,21 @@ int knot_cloud_list_devices(void)
  *
  * Returns: 0 if successful and a KNoT error otherwise.
  */
-int knot_cloud_publish_data(const char *id, uint8_t sensor_id,
-			    uint8_t value_type, const knot_value_type *value,
-			    uint8_t kval_len)
+int knot_cloud_publish_data(const char *id, unsigned char sensor_id,
+			    unsigned char value_type, void *value,
+			    unsigned char kval_len)
 {
 	json_object *jobj_data;
 	const char *json_str;
 	int result;
 
-	jobj_data = parser_data_create_object(id, sensor_id, value_type, value,
-					      kval_len);
+	knot_value_type *t_value = (knot_value_type *) value;
+	uint8_t t_sensor_id = (uint8_t) sensor_id;
+	uint8_t t_value_type = (uint8_t) value_type;
+	uint8_t t_kval_len = (uint8_t) kval_len;
+
+	jobj_data = parser_data_create_object(id, t_sensor_id, t_value_type, t_value,
+					      t_kval_len);
 	if (!jobj_data)
 		return KNOT_ERR_CLOUD_FAILURE;
 

--- a/src/knot_cloud.h
+++ b/src/knot_cloud.h
@@ -58,9 +58,9 @@ int knot_cloud_unregister_device(const char *id);
 int knot_cloud_auth_device(const char *id, const char *token);
 int knot_cloud_update_schema(const char *id, struct l_queue *schema_list);
 int knot_cloud_list_devices(void);
-int knot_cloud_publish_data(const char *id, uint8_t sensor_id,
-			    uint8_t value_type, const knot_value_type *value,
-			    uint8_t kval_len);
+int knot_cloud_publish_data(const char *id, unsigned char sensor_id,
+			    unsigned char value_type, void *value,
+			    unsigned char kval_len);
 int knot_cloud_read_start(const char *id, knot_cloud_cb_t read_handler_cb,
 			  void *user_data);
 int knot_cloud_start(char *url, char *user_token,
@@ -68,4 +68,3 @@ int knot_cloud_start(char *url, char *user_token,
 		     knot_cloud_disconnected_cb_t disconnected_cb,
 		     void *user_data);
 void knot_cloud_stop(void);
-


### PR DESCRIPTION
This patch removes the knot-protocol dependency from knot-cloud-sdk.

Changes:

- Change the parameter 'value' from the knot_cloud_publish_data
from knot_value_type to void type;
- Creates a auxiliar variable inside function body to cast the value
parameter to the right type to work with the parser_data_create_object
function;