### PR TITLE
Decouple knot_cloud from amqp calls

### DIFF
--- a/src/knot_cloud.c
+++ b/src/knot_cloud.c
@@ -41,7 +41,6 @@
 #include "knot_cloud.h"
 
 knot_cloud_cb_t knot_cloud_cb;
-amqp_bytes_t queue_fog;
 char *user_auth_token;
 char *knot_cloud_events[MSG_TYPES_LENGTH];
 
@@ -264,14 +263,14 @@ static int create_cloud_queue(const char *id)
 	snprintf(queue_fog_name, sizeof(queue_fog_name), "%s-%s",
 		 MQ_QUEUE_FOG_OUT, id);
 
-	queue_fog = mq_declare_new_queue(queue_fog_name);
-	if (queue_fog.bytes == NULL) {
+	err = mq_declare_new_queue(queue_fog_name);
+	if (err < 0) {
 		l_error("Error on declare a new queue");
-		return -1;
+		return err;
 	}
 
 	for (msg_type = UPDATE_MSG; msg_type < MSG_TYPES_LENGTH; msg_type++) {
-		err = mq_prepare_direct_queue(queue_fog, MQ_EXCHANGE_DEVICE,
+		err = mq_prepare_direct_queue(MQ_EXCHANGE_DEVICE,
 					      knot_cloud_events[msg_type]);
 		if (err) {
 			l_error("Error on set up queue to consume");
@@ -279,7 +278,7 @@ static int create_cloud_queue(const char *id)
 		}
 	}
 
-	err = mq_consumer_queue(queue_fog);
+	err = mq_consumer_queue();
 	if (err) {
 		l_error("Error on start a queue consumer");
 		return -1;
@@ -338,17 +337,6 @@ static int set_knot_cloud_events(const char *id)
 				l_strdup(binding_key_list_reply);
 
 	return 0;
-}
-
-static void destroy_cloud_queue(void)
-{
-	if (queue_fog.bytes) {
-		if (mq_delete_queue(queue_fog))
-			l_error("Error when delete Fog Queue");
-
-		amqp_bytes_free(queue_fog);
-		queue_fog = amqp_empty_bytes;
-	}
 }
 
 /**
@@ -651,7 +639,7 @@ int knot_cloud_read_start(const char *id, knot_cloud_cb_t read_handler_cb,
 	knot_cloud_cb = read_handler_cb;
 
 	/* Delete queues if already declared */
-	destroy_cloud_queue();
+	mq_delete_queue();
 
 	if (set_knot_cloud_events(id))
 		return -1;
@@ -679,8 +667,6 @@ int knot_cloud_start(char *url, char *user_token,
 
 void knot_cloud_stop(void)
 {
-	destroy_cloud_queue();
-
 	destroy_knot_cloud_events();
 	mq_stop();
 }

--- a/src/knot_cloud.c
+++ b/src/knot_cloud.c
@@ -40,40 +40,7 @@
 #include "parser.h"
 #include "knot_cloud.h"
 
-#define MQ_QUEUE_FOG_OUT "thingd-fogOut"
-
-/* Exchanges */
-#define MQ_EXCHANGE_DEVICE "device"
-#define MQ_EXCHANGE_DATA_SENT "data.sent"
-
-/* Headers */
-#define MQ_AUTHORIZATION_HEADER "Authorization"
-
-#define MQ_MSG_EXPIRATION_TIME_MS 2000
-
- /* Southbound traffic (commands) */
-#define MQ_EVENT_PREFIX_DEVICE "device"
-#define MQ_EVENT_POSTFIX_DATA_UPDATE "data.update"
-#define MQ_EVENT_POSTFIX_DATA_REQUEST "data.request"
-
-#define MQ_EVENT_DEVICE_REGISTERED "device.registered"
-#define MQ_EVENT_DEVICE_UNREGISTERED "device.unregistered"
-#define MQ_EVENT_DEVICE_SCHEMA_UPDATED "device.schema.updated"
-
-#define MQ_EVENT_AUTH_REPLY "thingd-auth-reply"
-#define MQ_EVENT_LIST_REPLY "thingd-list-reply"
-
- /* Northbound traffic (control, measurements) */
-#define MQ_CMD_DEVICE_REGISTER "device.register"
-#define MQ_CMD_DEVICE_UNREGISTER "device.unregister"
-#define MQ_CMD_DEVICE_AUTH "device.auth"
-#define MQ_CMD_SCHEMA_SENT "device.schema.sent"
-#define MQ_CMD_DEVICE_LIST "device.list"
-
-#define MQ_DEFAULT_CORRELATION_ID "default-corrId"
-
 knot_cloud_cb_t knot_cloud_cb;
-amqp_bytes_t queue_reply;
 amqp_bytes_t queue_fog;
 char *user_auth_token;
 char *knot_cloud_events[MSG_TYPES_LENGTH];

--- a/src/mq.h
+++ b/src/mq.h
@@ -18,6 +18,38 @@
  *  Message Queue header file
  */
 
+#define MQ_QUEUE_FOG_OUT "thingd-fogOut"
+
+/* Exchanges */
+#define MQ_EXCHANGE_DEVICE "device"
+#define MQ_EXCHANGE_DATA_SENT "data.sent"
+
+/* Headers */
+#define MQ_AUTHORIZATION_HEADER "Authorization"
+
+#define MQ_MSG_EXPIRATION_TIME_MS 2000
+
+ /* Southbound traffic (commands) */
+#define MQ_EVENT_PREFIX_DEVICE "device"
+#define MQ_EVENT_POSTFIX_DATA_UPDATE "data.update"
+#define MQ_EVENT_POSTFIX_DATA_REQUEST "data.request"
+
+#define MQ_EVENT_DEVICE_REGISTERED "device.registered"
+#define MQ_EVENT_DEVICE_UNREGISTERED "device.unregistered"
+#define MQ_EVENT_DEVICE_SCHEMA_UPDATED "device.schema.updated"
+
+#define MQ_EVENT_AUTH_REPLY "thingd-auth-reply"
+#define MQ_EVENT_LIST_REPLY "thingd-list-reply"
+
+ /* Northbound traffic (control, measurements) */
+#define MQ_CMD_DEVICE_REGISTER "device.register"
+#define MQ_CMD_DEVICE_UNREGISTER "device.unregister"
+#define MQ_CMD_DEVICE_AUTH "device.auth"
+#define MQ_CMD_SCHEMA_SENT "device.schema.sent"
+#define MQ_CMD_DEVICE_LIST "device.list"
+
+#define MQ_DEFAULT_CORRELATION_ID "default-corrId"
+
 typedef bool (*mq_read_cb_t) (const char *exchange, const char *routing_key,
 			      const char *body, void *user_data);
 typedef void (*mq_connected_cb_t) (void *user_data);

--- a/src/mq.h
+++ b/src/mq.h
@@ -84,14 +84,12 @@ typedef void (*mq_connected_cb_t) (void *user_data);
 typedef void (*mq_disconnected_cb_t) (void *user_data);
 
 int8_t mq_publish_message(const mq_message_data_t *message);
-int mq_prepare_direct_queue(amqp_bytes_t queue, const char *exchange,
-			    const char *routing_key);
-amqp_bytes_t mq_declare_new_queue(const char *name);
-int mq_delete_queue(amqp_bytes_t queue);
-int mq_consumer_queue(amqp_bytes_t queue);
-
+int mq_prepare_direct_queue(const char *exchange,
+			 const char *routing_key);
+int mq_declare_new_queue(const char *name);
+void mq_delete_queue(void);
+int mq_consumer_queue(void);
 int mq_set_read_cb(mq_read_cb_t read_cb, void *user_data);
-
 int mq_start(char *url, mq_connected_cb_t connected_cb,
 	     mq_disconnected_cb_t disconnected_cb, void *user_data,
 		 const char *user_token);

--- a/src/mq.h
+++ b/src/mq.h
@@ -50,30 +50,40 @@
 
 #define MQ_DEFAULT_CORRELATION_ID "default-corrId"
 
+/**
+ * @brief Defines the type of message.
+ *
+ * This enum defines the mq's message type.
+ */
+typedef enum {
+	MQ_MESSAGE_TYPE_DIRECT = 1,
+	MQ_MESSAGE_TYPE_DIRECT_RPC,
+	MQ_MESSAGE_TYPE_FANOUT
+} mq_message_type;
+
+/**
+ * @brief Defines a mq message format.
+ *
+ * A mq message to be exchange under amqp's protocol. This struct helds
+ * authorization parameters, a header, an expiration time for the message and
+ * the message's body.
+ */
+typedef struct {
+	mq_message_type msg_type;
+	const char *exchange;
+	const char *routing_key;
+	uint64_t expiration_ms;
+	const char *body;
+	const char *reply_to;
+	const char *correlation_id;
+} mq_message_data_t;
+
 typedef bool (*mq_read_cb_t) (const char *exchange, const char *routing_key,
 			      const char *body, void *user_data);
 typedef void (*mq_connected_cb_t) (void *user_data);
 typedef void (*mq_disconnected_cb_t) (void *user_data);
 
-int8_t mq_publish_direct_message_rpc(const char *exchange,
-				     const char *routing_key,
-				     amqp_table_entry_t *headers,
-				     size_t num_headers,
-				     uint64_t expiration_ms,
-				     amqp_bytes_t reply_to,
-				     const char *correlation_id,
-				     const char *body);
-int8_t mq_publish_direct_message(const char *exchange,
-				 const char *routing_key,
-				 amqp_table_entry_t *headers,
-				 size_t num_headers,
-				 uint64_t expiration_ms,
-				 const char *body);
-int8_t mq_publish_fanout_message(const char *exchange,
-				 amqp_table_entry_t *headers,
-				 size_t num_headers,
-				 uint64_t expiration_ms,
-				 const char *body);
+int8_t mq_publish_message(const mq_message_data_t *message);
 int mq_prepare_direct_queue(amqp_bytes_t queue, const char *exchange,
 			    const char *routing_key);
 amqp_bytes_t mq_declare_new_queue(const char *name);
@@ -83,5 +93,6 @@ int mq_consumer_queue(amqp_bytes_t queue);
 int mq_set_read_cb(mq_read_cb_t read_cb, void *user_data);
 
 int mq_start(char *url, mq_connected_cb_t connected_cb,
-	     mq_disconnected_cb_t disconnected_cb, void *user_data);
+	     mq_disconnected_cb_t disconnected_cb, void *user_data,
+		 const char *user_token);
 void mq_stop(void);


### PR DESCRIPTION
- Removes amqp direct calls from knot_cloud;
- Creates an unique publish message method in mq;
- Creates an enum to identify mq message type;
- Encapsulates mq messages in a struct mq_message_data_t;
- Removes unused queue_reply;
- Moves queue_fog to mq.c with a new name worker_queue;
- Moves mq message header to mq.c;
- Modifies mq.c to deal properly with worker_queue;
- Refactors knot_cloud to use mq_message_data_t struct.