### PR TITLE
Fix cloud log priority type

### DIFF
--- a/src/knot_cloud.c
+++ b/src/knot_cloud.c
@@ -30,6 +30,7 @@
 #include <stdbool.h>
 #include <stdint.h>
 #include <stdio.h>
+#include <errno.h>
 #include <ell/ell.h>
 #include <json-c/json.h>
 #include <amqp.h>
@@ -394,16 +395,26 @@ static void destroy_cloud_queue(void)
  *
  * Returns: void.
  */
-void knot_cloud_set_log_priority(char *priority)
+int knot_cloud_set_log_priority(int priority)
 {
-	if (!strcmp(priority,"error"))
+	switch (priority) {
+	case CLOUD_LOG_PRIORITY_ERROR:
 		log_set_priority(L_LOG_ERR);
-	else if (!strcmp(priority,"warn"))
+		break;
+	case CLOUD_LOG_PRIORITY_WARN:
 		log_set_priority(L_LOG_WARNING);
-	else if (!strcmp(priority,"info"))
+		break;
+	case CLOUD_LOG_PRIORITY_INFO:
 		log_set_priority(L_LOG_INFO);
-	else if (!strcmp(priority,"debug"))
+		break;
+	case CLOUD_LOG_PRIORITY_DEBUG:
 		log_set_priority(L_LOG_DEBUG);
+		break;
+	default:
+		return -EINVAL;
+	}
+
+	return 0;
 }
 
 /**

--- a/src/knot_cloud.h
+++ b/src/knot_cloud.h
@@ -19,6 +19,11 @@
  *
  */
 
+#define CLOUD_LOG_PRIORITY_ERROR 3
+#define CLOUD_LOG_PRIORITY_WARN 4
+#define CLOUD_LOG_PRIORITY_INFO 6
+#define CLOUD_LOG_PRIORITY_DEBUG 7
+
 struct knot_cloud_device {
 	char *id;
 	char *uuid;
@@ -52,7 +57,7 @@ typedef bool (*knot_cloud_cb_t) (const struct knot_cloud_msg *msg,
 typedef void (*knot_cloud_connected_cb_t) (void *user_data);
 typedef void (*knot_cloud_disconnected_cb_t) (void *user_data);
 
-void knot_cloud_set_log_priority(char *priority);
+int knot_cloud_set_log_priority(int priority);
 int knot_cloud_register_device(const char *id, const char *name);
 int knot_cloud_unregister_device(const char *id);
 int knot_cloud_auth_device(const char *id, const char *token);


### PR DESCRIPTION
This patch changes the log_priority from char* to int to match the
virtualthing log_priority type.