### PR TITLE
Add timestamp to json message

### DIFF
--- a/src/knot_cloud.c
+++ b/src/knot_cloud.c
@@ -547,13 +547,13 @@ int knot_cloud_list_devices(void)
  */
 int knot_cloud_publish_data(const char *id, uint8_t sensor_id,
 			    uint8_t value_type, const knot_value_type *value,
-			    uint8_t kval_len)
+			    uint8_t kval_len, struct tm *ptm)
 {
 	char *json_str;
 	int result;
 
 	json_str = parser_data_create_object(id, sensor_id, value_type, value,
-					      kval_len);
+					      kval_len, ptm);
 	if (!json_str)
 		return KNOT_ERR_CLOUD_FAILURE;
 

--- a/src/knot_cloud.h
+++ b/src/knot_cloud.h
@@ -65,7 +65,7 @@ int knot_cloud_update_config(const char *id, struct l_queue *config_list);
 int knot_cloud_list_devices(void);
 int knot_cloud_publish_data(const char *id, uint8_t sensor_id,
 			    uint8_t value_type, const knot_value_type *value,
-			    uint8_t kval_len);
+			    uint8_t kval_len, struct tm *ptm);
 int knot_cloud_read_start(const char *id, knot_cloud_cb_t read_handler_cb,
 			  void *user_data);
 int knot_cloud_start(char *url, char *user_token,

--- a/src/parser.h
+++ b/src/parser.h
@@ -34,6 +34,7 @@
 #define KNOT_JSON_FIELD_TIME_SEC	"timeSec"
 #define KNOT_JSON_FIELD_LOWER_THRESHOLD	"lowerThreshold"
 #define KNOT_JSON_FIELD_UPPER_THRESHOLD	"upperThreshold"
+#define KNOT_JSON_FIELD_TIMESTAMP	"timestamp"
 
 typedef void *(create_device_item_cb) (const char *id, const char *name,
 				       struct l_queue *schema);
@@ -44,7 +45,8 @@ struct l_queue *parser_update_to_list(const char *json_str);
 char *parser_data_create_object(const char *device_id, uint8_t sensor_id,
 				uint8_t value_type,
 				const knot_value_type *value,
-				uint8_t kval_len);
+				uint8_t kval_len,
+				struct tm *ptm);
 struct l_queue *parser_config_to_list(const char *json_str);
 struct l_queue *parser_queue_from_json_array(const char *json_str,
 					     create_device_item_cb item_cb);


### PR DESCRIPTION
Add timestamp to json message:
- Add timestamp field to json message structure;
- Add time acquisition via time library.