### PR TITLE
Add the possibility of reading with more dataitens

### DIFF
--- a/src/knot_cloud.c
+++ b/src/knot_cloud.c
@@ -549,7 +549,7 @@ int knot_cloud_list_devices(void)
  *
  * Returns: 0 if successful and a KNoT error otherwise.
  */
-int knot_cloud_publish_data(const char *id, uint8_t sensor_id,
+int knot_cloud_publish_data(const char *id, int sensor_id,
 			    uint8_t value_type, const knot_value_type *value,
 			    uint8_t kval_len, struct tm *ptm)
 {

--- a/src/knot_cloud.h
+++ b/src/knot_cloud.h
@@ -64,7 +64,7 @@ int knot_cloud_unregister_device(const char *id);
 int knot_cloud_auth_device(const char *id, const char *token);
 int knot_cloud_update_config(const char *id, struct l_queue *config_list);
 int knot_cloud_list_devices(void);
-int knot_cloud_publish_data(const char *id, uint8_t sensor_id,
+int knot_cloud_publish_data(const char *id, int sensor_id,
 			    uint8_t value_type, const knot_value_type *value,
 			    uint8_t kval_len, struct tm *ptm);
 int knot_cloud_read_start(const char *id, knot_cloud_cb_t read_handler_cb,

--- a/src/parser.c
+++ b/src/parser.c
@@ -228,9 +228,6 @@ static json_object *event_item_create_obj(knot_msg_config *config)
 		json_object_object_add(json_event, KNOT_JSON_FIELD_CHANGE,
 				       json_object_new_boolean(true));
 
-	json_object_object_add(json_event, KNOT_JSON_FIELD_TIME_SEC,
-			       json_object_new_int(config->event.time_sec));
-
 	if (config->event.event_flags & KNOT_EVT_FLAG_LOWER_THRESHOLD)
 		json_object_object_add(json_event,
 				KNOT_JSON_FIELD_LOWER_THRESHOLD,
@@ -315,7 +312,7 @@ static int get_event(knot_event *event, json_object *data)
 {
 	json_object *jobjkey, *jobj_event;
 	knot_value_type lower_threshold, upper_threshold;
-	int sensor_id, time_sec;
+	int sensor_id;
 	uint8_t evt_flag;
 	bool change;
 
@@ -338,18 +335,6 @@ static int get_event(knot_event *event, json_object *data)
 	if (change)
 		evt_flag |= KNOT_EVT_FLAG_CHANGE;
 
-	/* Getting 'timeSec' */
-	if (json_object_object_get_ex(jobj_event, KNOT_JSON_FIELD_TIME_SEC,
-				      &jobjkey)) {
-
-		if (json_object_get_type(jobjkey) != json_type_int)
-			return -1;
-
-		time_sec = json_object_get_int(jobjkey);
-
-		evt_flag |= KNOT_EVT_FLAG_TIME;
-	}
-
 	/* Getting 'lowerThreshold' */
 	if (json_object_object_get_ex(jobj_event,
 				      KNOT_JSON_FIELD_LOWER_THRESHOLD,
@@ -370,7 +355,6 @@ static int get_event(knot_event *event, json_object *data)
 		evt_flag |= KNOT_EVT_FLAG_UPPER_THRESHOLD;
 	}
 
-	event->time_sec = time_sec;
 	event->lower_limit = lower_threshold;
 	event->upper_limit = upper_threshold;
 	event->event_flags = evt_flag;
@@ -722,18 +706,20 @@ struct l_queue *parser_config_to_list(const char *json_str)
 			break;
 		}
 
-		if (get_sensor_id(&sensor_id_aux, jobjentry) < 0) {
+		if (get_sensor_id(&sensor_id_aux, jobjentry) <
+				KNOT_STATUS_OK) {
 			err = true;
 			break;
 		}
 		config->sensor_id = sensor_id_aux;
 
-		if (get_schema(&config->schema, jobjentry) < 0) {
+		if (get_schema(&config->schema, jobjentry) <
+			KNOT_STATUS_OK) {
 			err = true;
 			break;
 		}
 
-		if (get_event(&config->event, jobjentry) < 0) {
+		if (get_event(&config->event, jobjentry) < KNOT_STATUS_OK) {
 			config->event.event_flags &= KNOT_EVT_FLAG_NONE;
 			config->event.event_flags |= KNOT_EVT_FLAG_UNREGISTERED;
 		}

--- a/src/parser.h
+++ b/src/parser.h
@@ -42,7 +42,7 @@ typedef void *(create_device_item_cb) (const char *id, const char *name,
 char *parser_config_create_object(const char *device_id,
 					 struct l_queue *config_list);
 struct l_queue *parser_update_to_list(const char *json_str);
-char *parser_data_create_object(const char *device_id, uint8_t sensor_id,
+char *parser_data_create_object(const char *device_id, int sensor_id,
 				uint8_t value_type,
 				const knot_value_type *value,
 				uint8_t kval_len,

--- a/src/parser.h
+++ b/src/parser.h
@@ -31,7 +31,6 @@
 #define KNOT_JSON_FIELD_TYPE_ID		"typeId"
 #define KNOT_JSON_FIELD_ERROR		"error"
 #define KNOT_JSON_FIELD_CHANGE		"change"
-#define KNOT_JSON_FIELD_TIME_SEC	"timeSec"
 #define KNOT_JSON_FIELD_LOWER_THRESHOLD	"lowerThreshold"
 #define KNOT_JSON_FIELD_UPPER_THRESHOLD	"upperThreshold"
 #define KNOT_JSON_FIELD_TIMESTAMP	"timestamp"


### PR DESCRIPTION
Add the possibility of reading with more dataitens:

- Added full-time flow to all tags;
- Modified the type of variable responsible for sensor id. Because with uin8_t we can only have 255 sensors. We were having a problem that truncating the value.